### PR TITLE
fix bug

### DIFF
--- a/src/angular-indexed-db.coffee
+++ b/src/angular-indexed-db.coffee
@@ -120,8 +120,11 @@ angular.module('indexedDB', []).provider '$indexedDB', ->
         db = null
         dbPromise = null
 
-    validateStoreNames = (storeNames) ->
-      db.objectStoreNames.contains(storeNames)
+    validateStoreNames = (storeNames)->
+      for storeName in storeNames
+        console.log storeName
+        return false if not db.objectStoreNames.contains storeName
+      true
 
     openTransaction = (storeNames, mode = dbMode.readonly) ->
       openDatabase().then ->

--- a/test/spec/angular-indexeddb-spec.coffee
+++ b/test/spec/angular-indexeddb-spec.coffee
@@ -37,11 +37,14 @@ describe "$indexedDB", ->
   describe "#openStores", ->
 
     itPromises "returns the object stores", ->
-      @subject.openStores ["TestObjects","ComplexTestObjecs"] , (store1, store2) ->
+      @subject.openStores ["TestObjects","ComplexTestObjects"] , (store1, store2) ->
         store1.insert({id: 1, data : "foo"})
         store2.insert({id: 2, name: "barf"})
         store1.getAllKeys().then (keys) ->
           expect(keys.length).toEqual(1)
+      .catch (err)->
+        # not run to here
+        expect(err).toBeUndefined()
 
   describe "#openAllStores", ->
       itPromises "returns all the object stores", ->


### PR DESCRIPTION
  db.objectStoreNames.contains not support array
  validateStoreNames and test-spec not work correctly

tested, not push the generated files, and not updated the version 

By the way , 
1. compile coffee file to /angular-indexed-db.js (not the same dir of coffee file ) is not convenient to debug.
2. what's the '"grunt-haml' for , it make some trouble to install ( on windows )
