### PR TITLE
Make angular-indexed-db work on Safari

### DIFF
--- a/angular-indexed-db.js
+++ b/angular-indexed-db.js
@@ -124,11 +124,15 @@
           };
           dbReq.onblocked = dbReq.onerror = rejectWithError(deferred);
           dbReq.onupgradeneeded = function(event) {
-            var tx;
+            var tx, oldVersion;
+            oldVersion = event.oldVersion;
+            if(oldVersion > 99999999999){
+                oldVersion = 0;
+            }
             db = event.target.result;
             tx = event.target.transaction;
-            console.debug("$indexedDB: Upgrading database '" + db.name + "' from version " + event.oldVersion + " to version " + event.newVersion + " ...");
-            applyNeededUpgrades(event.oldVersion, event, db, tx);
+            console.debug("$indexedDB: Upgrading database '" + db.name + "' from version " + oldVersion + " to version " + event.newVersion + " ...");
+            applyNeededUpgrades(oldVersion, event, db, tx);
           };
           return deferred.promise;
         };
@@ -166,6 +170,7 @@
           if (options.beginKey && options.endKey) {
             return IDBKeyRange.bound(options.beginKey, options.endKey);
           }
+          return null;
         };
         addTransaction = function(transaction) {
           allTransactions.push(transaction.promise);


### PR DESCRIPTION
Sorry for the late reply.

Safari indexeddb reports a big DB version.
KeyRangeForOptions must return null if no begin and end keys are present.
