### PR TITLE
Safari fix: now in coffee script

### DIFF
--- a/angular-indexed-db.js
+++ b/angular-indexed-db.js
@@ -124,11 +124,15 @@
           };
           dbReq.onblocked = dbReq.onerror = rejectWithError(deferred);
           dbReq.onupgradeneeded = function(event) {
-            var tx;
+            var tx, oldVersion;
+            oldVersion = event.oldVersion;
+            if(oldVersion > 99999999999){
+                oldVersion = 0;
+            }
             db = event.target.result;
             tx = event.target.transaction;
-            console.debug("$indexedDB: Upgrading database '" + db.name + "' from version " + event.oldVersion + " to version " + event.newVersion + " ...");
-            applyNeededUpgrades(event.oldVersion, event, db, tx);
+            console.debug("$indexedDB: Upgrading database '" + db.name + "' from version " + oldVersion + " to version " + event.newVersion + " ...");
+            applyNeededUpgrades(oldVersion, event, db, tx);
           };
           return deferred.promise;
         };
@@ -166,6 +170,7 @@
           if (options.beginKey && options.endKey) {
             return IDBKeyRange.bound(options.beginKey, options.endKey);
           }
+          return null;
         };
         addTransaction = function(transaction) {
           allTransactions.push(transaction.promise);

--- a/src/angular-indexed-db.coffee
+++ b/src/angular-indexed-db.coffee
@@ -111,10 +111,13 @@ angular.module('indexedDB', []).provider '$indexedDB', ->
         return
       dbReq.onblocked = dbReq.onerror = rejectWithError(deferred)
       dbReq.onupgradeneeded = (event) ->
+        oldVersion = event.oldVersion
+        if oldVersion > 99999999999
+            oldVersion = 0
         db = event.target.result
         tx = event.target.transaction
-        console.debug "$indexedDB: Upgrading database '#{db.name}' from version #{event.oldVersion} to version #{event.newVersion} ..."
-        applyNeededUpgrades event.oldVersion, event, db, tx
+        console.debug "$indexedDB: Upgrading database '#{db.name}' from version #{oldVersion} to version #{event.newVersion} ..."
+        applyNeededUpgrades oldVersion, event, db, tx
         return
       deferred.promise
 
@@ -141,7 +144,10 @@ angular.module('indexedDB', []).provider '$indexedDB', ->
 
 
     keyRangeForOptions = (options) ->
-      IDBKeyRange.bound(options.beginKey, options.endKey) if options.beginKey and options.endKey
+      if options.beginKey and options.endKey
+         IDBKeyRange.bound(options.beginKey, options.endKey)
+      else
+         null
 
     addTransaction = (transaction) ->
       allTransactions.push(transaction.promise)


### PR DESCRIPTION
First time wrote coffee.
Making the build with grunt build, all test passed and the JS file is like the desired one.
In Safari, the version for the DB at the beginning is 9223372036854776000, so that 9999... assumes we didn't updated the db such many times.
