### PR TITLE
ShimIndexedDB support

### DIFF
--- a/angular-indexed-db.js
+++ b/angular-indexed-db.js
@@ -13,7 +13,7 @@
   angular.module('indexedDB', []).provider('$indexedDB', function() {
     var IDBKeyRange, allTransactions, apiDirection, appendResultsToPromise, applyNeededUpgrades, cursorDirection, db, dbMode, dbName, dbPromise, dbVersion, defaultQueryOptions, errorMessageFor, indexedDB, readyState, upgradesByVersion;
     indexedDB = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB;
-    IDBKeyRange = window.IDBKeyRange || window.mozIDBKeyRange || window.webkitIDBKeyRange || window.msIDBKeyRange;
+    IDBKeyRange = window.IDBKeyRange || window.mozIDBKeyRange || window.webkitIDBKeyRange || window.msIDBKeyRange || window.shimIndexedDB;
     dbMode = {
       readonly: "readonly",
       readwrite: "readwrite"


### PR DESCRIPTION
I'm using your angularjs indexeddb module for iOS support I had to fix putting the following code into 
angular-indexed-db.js on line 15

indexedDB = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB || window.shimIndexedDB;