### PR TITLE
Workaround for IE throwing InvalidAccessError on db open. Fixes #32

### DIFF
--- a/src/angular-indexed-db.coffee
+++ b/src/angular-indexed-db.coffee
@@ -102,7 +102,8 @@ angular.module('indexedDB', []).provider '$indexedDB', ->
 
     createDatabaseConnection = ->
       deferred = $q.defer()
-      dbReq = indexedDB.open(dbName, dbVersion or 1)
+      # IE11 workaround - parseInt reminds IE that dbVersion is actually a number
+      dbReq = indexedDB.open(dbName, parseInt(dbVersion) or 1)
       dbReq.onsuccess = ->
         db = dbReq.result
         $rootScope.$apply ->


### PR DESCRIPTION
Despite `typeof dbVersion` equalling `"number"` in IE, it throws an InvalidAccessError when attempting to call open. `parseInt` still results in `dbVersion` being a number, as you'd expect, but seems to remind IE of what it's getting.